### PR TITLE
Added escapes in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ LTL2C = $(addprefix src/,\
 DEPS = $(LTL2C:.o=.d) src/main.d
 
 VERS := $(shell \
-	printf '#include "inc/ltl2ba.h"\nLTL2BA_VERSION_MAJOR LTL2BA_VERSION_MINOR' | \
+	printf '\#include "inc/ltl2ba.h"\nLTL2BA_VERSION_MAJOR LTL2BA_VERSION_MINOR' | \
 	$(CC) -x c -E - | tail -n1 | tr ' ' .)
 
 # rules


### PR DESCRIPTION
Thanks for this project that really solved my problem! 

When running make in the latest branch in Ubuntu 20.04, I got this error:

```bash
user@user-VirtualBox:~/tools/libltl2ba$ make
Makefile:57: *** unterminated call to function 'shell': missing ')'.  Stop.
```

I found that this error might be due to the missing of backslash before the `#` symbol. So I added the backslash and then this project built successfully.